### PR TITLE
Stop generating shell related code on `docs.rs`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@
 // You should have received a copy of the MIT License along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use std::env;
 use std::fs;
 
 use clap::IntoApp;
@@ -20,16 +21,18 @@ pub mod stored {
 }
 
 fn main() -> Result<(), configure_me_codegen::Error> {
-    let outdir = "./shell";
+    if env::var("DOCS_RS").is_err() {
+        let outdir = "./shell";
+        fs::create_dir_all(outdir.clone()).expect("failed to create shell dir");
+        for app in [stored::Opts::command()].iter_mut() {
+            let name = app.get_name().to_string();
+            generate_to(Bash, app, &name, &outdir)?;
+            generate_to(PowerShell, app, &name, &outdir)?;
+            generate_to(Zsh, app, &name, &outdir)?;
+        }
 
-    fs::create_dir_all(outdir).expect("failed to create shell dir");
-    for app in [stored::Opts::command()].iter_mut() {
-        let name = app.get_name().to_string();
-        generate_to(Bash, app, &name, &outdir)?;
-        generate_to(PowerShell, app, &name, &outdir)?;
-        generate_to(Zsh, app, &name, &outdir)?;
+        // configure_me_codegen::build_script_auto()
     }
 
-    // configure_me_codegen::build_script_auto()
     Ok(())
 }


### PR DESCRIPTION
This will fix Storm-WG/storm-stored#5.
See also: https://docs.rs/about/builds#detecting-docsrs
